### PR TITLE
Interpolate environment variables.

### DIFF
--- a/bin/plenv-use
+++ b/bin/plenv-use
@@ -25,7 +25,7 @@ if ($lib_name) {
     die "lib $perl_ver\@$lib_name doesn't exist. Create it first with 'plenv lib create'"
         unless -d $local_lib;
     require local::lib;
-    my %env = local::lib->build_environment_vars_for($local_lib, 0, 0);
+    my %env = local::lib->build_environment_vars_for($local_lib, 0, local::lib->INTERPOLATE_ENV);
     @ENV{keys %env} = values %env;
 }
 


### PR DESCRIPTION
When the last argument of `local::lib->build_environment_vars_for` is
`0`, which equals to `local::lib->LITERAL_ENV`, the new sub-shell of
`plenv use` will not expand `$PATH`.

E.g., run `plenv use @MODULE`, then display the value of `PATH` in the
new sub-shell:

```
$ echo $PATH
/home/noname/.plenv/libs/5.18.1@MODULE/bin:$PATH
```

The `$PATH` part of the output is literal, not expanded.

Fix it by passing `local::lib->INTERPOLATE_ENV` (whose value is `1`).
