### PR TITLE
fail if requested to "use" a non-existent version of Perl

### DIFF
--- a/bin/plenv-use
+++ b/bin/plenv-use
@@ -22,6 +22,9 @@ sub resolve_name {
     my $name = shift;
 
     my($perl_ver, $lib_name) = split /@/, $name, 2;
+
+    exit 1 if $perl_ver ne '' && do { `plenv prefix $perl_ver`; $?  };
+
     $perl_ver ||= current_perl;
 
     ($perl_ver, $lib_name);


### PR DESCRIPTION
Specifying a non-existent Perl version without a lib doesn't cause an error:

```
% plenv prefix huh
plenv: version `huh' not installed

% plenv use huh

A sub-shell is launched with PLENV_VERSION=huh. Run 'exit' to finish it.


% plenv which perl
plenv: version `huh' is not installed
```

With this patch:

```
% plenv use huh
plenv: version `huh' not installed
```
