### PR TITLE
enable local::lib at plenv-exec time rather than when plenv-use execs…

### DIFF
--- a/bin/plenv-use
+++ b/bin/plenv-use
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env bash
 #
 # Summary: Launches a new shell with specified perl and/or local::lib path
 #
@@ -11,42 +11,48 @@
 #
 # When the perl version is empty, the current perl version is used.
 
-use strict;
+resolve_name () {
 
-sub current_perl {
-    chomp(my $version = `plenv version-name`);
-    $version;
+    local name=$1
+
+    local sIFS=$IFS
+    IFS='|'
+    read perl_ver lib_name < <(perl -e "\$,=q[|]; print split /@/, q[$name], 2" )
+    IFS="$sIFS"
+
+    test -z "$perl_ver" && perl_ver="$(plenv version-name)"
+
+    if ! plenv prefix "$perl_ver" > /dev/null ; then
+	exit 1
+    fi
+
+    export PLENV_VERSION="$perl_ver"
+
+    if [ -n "$lib_name" ]; then
+	local lib=$PLENV_VERSION@$lib_name
+	local local_lib=$PLENV_ROOT/libs/$lib
+
+	if [ ! -d $local_lib ] ; then
+	    echo "lib $lib doesn't exist. Create it first with 'plenv lib create $lib'" >&2
+	    exit 1
+	fi
+
+	export PLENV_USE_LIB="$lib_name"
+    fi
+
 }
 
-sub resolve_name {
-    my $name = shift;
+perl_with_lib=$1
 
-    my($perl_ver, $lib_name) = split /@/, $name, 2;
-    $perl_ver ||= current_perl;
+if [ -z "$perl_with_lib" ] ; then
+    echo "Usage: plenv use perl-version[\@lib]" >&2
+    exit 1
+fi
 
-    ($perl_ver, $lib_name);
-}
+resolve_name "$perl_with_lib"
 
-my $perl_with_lib = shift
-    or die "Usage: plenv use perl-version[\@lib]\n";
+echo ; echo -n  "A sub-shell is launched with PLENV_VERSION=$PLENV_VERSION"
+test -n "$PLENV_USE_LIB" && echo -n " and PLENV_USE_LIB=$PLENV_USE_LIB"
+echo ". Run 'exit' to finish it.\n\n";
 
-my($perl_ver, $lib_name) = resolve_name($perl_with_lib);
-
-if ($lib_name) {
-    my $local_lib = "$ENV{PLENV_ROOT}/libs/$perl_ver\@$lib_name";
-    die "lib $perl_ver\@$lib_name doesn't exist. Create it first with 'plenv lib create'"
-        unless -d $local_lib;
-    require local::lib;
-    my %env = local::lib->build_environment_vars_for($local_lib,
-        ($local::lib::VERSION > 1.008026) ? () : (0, local::lib->INTERPOLATE_ENV));
-
-    @ENV{keys %env} = values %env;
-}
-
-$ENV{PLENV_VERSION} = $perl_ver;
-
-print "\nA sub-shell is launched with PLENV_VERSION=$perl_ver";
-print " and local::lib activated for \@$lib_name" if $lib_name;
-print ". Run 'exit' to finish it.\n\n";
-
-exec $ENV{SHELL};
+exec "$SHELL"

--- a/bin/plenv-use
+++ b/bin/plenv-use
@@ -51,8 +51,8 @@ fi
 
 resolve_name "$perl_with_lib"
 
-echo ; echo -n  "A sub-shell is launched with PLENV_VERSION=$PLENV_VERSION"
+echo -ne "\nA sub-shell is launched with PLENV_VERSION=$PLENV_VERSION"
 test -n "$PLENV_USE_LIB" && echo -n " and PLENV_USE_LIB=$PLENV_USE_LIB"
-echo ". Run 'exit' to finish it.\n\n";
+echo -e ". Run 'exit' to finish it.\n\n";
 
 exec "$SHELL"

--- a/etc/plenv.d/exec/plenv_use_lib.bash
+++ b/etc/plenv.d/exec/plenv_use_lib.bash
@@ -3,8 +3,8 @@
 #
 
 if [ -n "$PLENV_USE_LIB" ]; then
-    local lib=${PLENV_VERSION}@${PLENV_USE_LIB}
-    local local_lib=$PLENV_ROOT/libs/$lib
+    lib=${PLENV_VERSION}@${PLENV_USE_LIB}
+    local_lib=$PLENV_ROOT/libs/$lib
 
     if [ ! -d "$local_lib" ]; then
 

--- a/etc/plenv.d/exec/plenv_use_lib.bash
+++ b/etc/plenv.d/exec/plenv_use_lib.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+#
+
+if [ -n "$PLENV_USE_LIB" ]; then
+    local lib=${PLENV_VERSION}@${PLENV_USE_LIB}
+    local local_lib=$PLENV_ROOT/libs/$lib
+
+    if [ ! -d "$local_lib" ]; then
+
+	echo "lib $lib doesn't exist. Create it first with 'PLENV_USE_LIB= plenv lib create $lib'"
+	exit 1
+    fi
+
+    eval $($(plenv which perl) -Mlocal::lib -e 'local::lib->print_environment_vars_for(q['"$local_lib"'],(\$local::lib::VERSION > 1.008026) ? () : (0, local::lib->INTERPOLATE_ENV));')
+fi


### PR DESCRIPTION
… a shell

plenv-use used local::lib to set the various PERL5\* environment
variables and then exec'd a new shell.

However, there is no means of guaranteeing that the new shell's
environment will retain the modified PERL5\* variables.  Paranoid shell
startup scripts may completely scrub the existing environment.

The only way of avoiding this is to have the local::lib'd environment
set during plenv's exec phase.  This is done with a custom exec hook.

plenv-use now simply checks if the requested lib is available and sets
PLENV_USE_LIB to that value.

The plenv_use_lib.bash exec hook uses local::lib to modify the
current environment.
