### PR TITLE
add which hook to find executables in local::lib's bin directory

### DIFF
--- a/etc/plenv.d/which/which_plenv-contrib.bash
+++ b/etc/plenv.d/which/which_plenv-contrib.bash
@@ -1,0 +1,4 @@
+
+if [ -n "$PERL_LOCAL_LIB_ROOT" -a -x "${PERL_LOCAL_LIB_ROOT}/bin/${PLENV_COMMAND}" ] ; then
+    PLENV_COMMAND_PATH="${PERL_LOCAL_LIB_ROOT}/bin/${PLENV_COMMAND}"
+fi


### PR DESCRIPTION
This implements a hook for to plenv-which which checks in local::lib's bin directory for executables.
This resolves #8 .